### PR TITLE
add `delete_merged_file: true`

### DIFF
--- a/book/_bookdown.yml
+++ b/book/_bookdown.yml
@@ -1,3 +1,4 @@
 book_filename: vistransrep
 repo: https://github.com/krlmlr/vistransrep/
 split_by: section
+delete_merged_file: true


### PR DESCRIPTION
removes the tedious need for manual deletion of the merged file bookdown Rmd if one wants to call `bookdown::serve_book()` a second time. 